### PR TITLE
Fix Broken Link on Getting Started for MATRIX CORE

### DIFF
--- a/docs/matrix-core/index.md
+++ b/docs/matrix-core/index.md
@@ -14,7 +14,7 @@ See [Installation](getting-started/installation.md)
 
 ## Examples
 
-See [JS Test Example](examples/tests.md)
+See [JS Test Example](examples/jstests.md)
 
 See [Python Test Example](examples/pytests.md)
 


### PR DESCRIPTION
Fix Broken Link on Getting Started for MATRIX CORE